### PR TITLE
Align Seton restyle accent with green palette

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { Link, Navigate, Route, Routes } from 'react-router-dom';
+import { Link, Navigate, NavLink, Route, Routes } from 'react-router-dom';
 import { useAuth } from './context/AuthContext';
 import LoginPage from './pages/LoginPage';
 import JudgePage from './pages/JudgePage';
@@ -8,6 +8,7 @@ import LeaderboardPage from './pages/LeaderboardPage';
 import NotFoundPage from './pages/NotFoundPage';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import type { UserRole } from './api/types';
+import logo from './assets/znak_SPTO_transparent.png';
 
 const defaultRouteByRole: Record<UserRole, string> = {
   judge: '/judge',
@@ -30,61 +31,94 @@ export default function App() {
   return (
     <div className="app">
       <header className="app__header">
-        <div className="app__title">
-          <Link to="/leaderboard">Dračí smyčka</Link>
-        </div>
-        <nav className="app__nav">
-          <Link to="/leaderboard">Výsledky</Link>
-          {state?.user.role === 'judge' || state?.user.role === 'admin' ? <Link to="/judge">Rozhodčí</Link> : null}
-          {state && (state.user.role === 'calculator' || state.user.role === 'admin') ? (
-            <Link to="/calculator">Výpočetka</Link>
-          ) : null}
-          {state?.user.role === 'admin' ? <Link to="/admin">Administrace</Link> : null}
-        </nav>
-        <div className="app__user">
-          {state ? (
-            <>
-              <span>{state.user.displayName}</span>
-              <button type="button" onClick={() => logout()}>
-                Odhlásit
-              </button>
-            </>
-          ) : (
-            <Link to="/login">Přihlásit</Link>
-          )}
+        <div className="app__header-inner">
+          <div className="app__brand">
+            <img className="app__logo" src={logo} alt="Logo SPTO" />
+            <div className="app__brand-text">
+              <Link className="app__title" to="/leaderboard">
+                Dračí smyčka
+              </Link>
+              <span className="app__subtitle">Scoreboard SPTO</span>
+            </div>
+          </div>
+          <nav className="app__nav">
+            <NavLink className={({ isActive }) => (isActive ? 'app__nav-link app__nav-link--active' : 'app__nav-link')} to="/leaderboard">
+              Výsledky
+            </NavLink>
+            {state?.user.role === 'judge' || state?.user.role === 'admin' ? (
+              <NavLink
+                className={({ isActive }) => (isActive ? 'app__nav-link app__nav-link--active' : 'app__nav-link')}
+                to="/judge"
+              >
+                Rozhodčí
+              </NavLink>
+            ) : null}
+            {state && (state.user.role === 'calculator' || state.user.role === 'admin') ? (
+              <NavLink
+                className={({ isActive }) => (isActive ? 'app__nav-link app__nav-link--active' : 'app__nav-link')}
+                to="/calculator"
+              >
+                Výpočetka
+              </NavLink>
+            ) : null}
+            {state?.user.role === 'admin' ? (
+              <NavLink
+                className={({ isActive }) => (isActive ? 'app__nav-link app__nav-link--active' : 'app__nav-link')}
+                to="/admin"
+              >
+                Administrace
+              </NavLink>
+            ) : null}
+          </nav>
+          <div className="app__user">
+            {state ? (
+              <>
+                <span className="app__user-name">{state.user.displayName}</span>
+                <button className="app__user-action" type="button" onClick={() => logout()}>
+                  Odhlásit
+                </button>
+              </>
+            ) : (
+              <Link className="app__user-login" to="/login">
+                Přihlásit
+              </Link>
+            )}
+          </div>
         </div>
       </header>
       <main className="app__main">
-        <Routes>
-          <Route path="/" element={<DefaultRoute />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route
-            path="/judge"
-            element={
-              <ProtectedRoute allowedRoles={['judge']}>
-                <JudgePage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/calculator"
-            element={
-              <ProtectedRoute allowedRoles={['calculator']}>
-                <CalculatorPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/admin"
-            element={
-              <ProtectedRoute allowedRoles={['admin']}>
-                <AdminPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route path="/leaderboard" element={<LeaderboardPage />} />
-          <Route path="*" element={<NotFoundPage />} />
-        </Routes>
+        <div className="app__main-inner">
+          <Routes>
+            <Route path="/" element={<DefaultRoute />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route
+              path="/judge"
+              element={
+                <ProtectedRoute allowedRoles={['judge']}>
+                  <JudgePage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/calculator"
+              element={
+                <ProtectedRoute allowedRoles={['calculator']}>
+                  <CalculatorPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/admin"
+              element={
+                <ProtectedRoute allowedRoles={['admin']}>
+                  <AdminPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route path="/leaderboard" element={<LeaderboardPage />} />
+            <Route path="*" element={<NotFoundPage />} />
+          </Routes>
+        </div>
       </main>
     </div>
   );

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,7 +1,20 @@
 :root {
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  color: #0d1f2d;
-  background-color: #f4f6f8;
+  --color-navy-900: #040f1f;
+  --color-navy-800: #081a2d;
+  --color-navy-700: #103659;
+  --color-navy-600: #1a4f7d;
+  --color-cream-200: #edf3ff;
+  --color-cream-100: #f9fbff;
+  --color-text: #0b1628;
+  --color-text-muted: #425572;
+  --color-accent-500: #34d399;
+  --color-accent-600: #22c55e;
+  font-family: 'Inter', 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  color: #f4f7ff;
+  background-color: var(--color-navy-900);
 }
 
 * {
@@ -10,7 +23,13 @@
 
 body {
   margin: 0;
-  background: var(--bg, #f4f6f8);
+  min-height: 100vh;
+  background: radial-gradient(120% 120% at 15% 0%, rgba(31, 79, 124, 0.55) 0%, rgba(10, 31, 54, 0.94) 50%, #040f1f 100%);
+  color: inherit;
+}
+
+a {
+  color: inherit;
 }
 
 button,
@@ -24,38 +43,99 @@ textarea {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  background: linear-gradient(160deg, rgba(4, 15, 31, 0.96) 0%, rgba(7, 25, 46, 0.96) 48%, rgba(3, 13, 26, 0.98) 100%);
 }
 
 .app__header {
-  background: #123456;
-  color: #fff;
-  padding: 0.75rem 1.5rem;
+  padding: 1.5rem 0 1rem;
+}
+
+.app__header-inner {
+  width: min(1120px, calc(100% - 3rem));
+  margin: 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 1.75rem;
+  background: rgba(8, 26, 45, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1rem 1.5rem;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 24px 64px rgba(3, 10, 21, 0.45);
 }
 
-.app__title a {
-  color: inherit;
+.app__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  min-width: 0;
+}
+
+.app__logo {
+  width: 52px;
+  height: 52px;
+  object-fit: contain;
+  filter: drop-shadow(0 8px 18px rgba(0, 0, 0, 0.35));
+}
+
+.app__brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.app__title {
+  color: #ffffff;
   text-decoration: none;
+  font-size: 1.5rem;
   font-weight: 700;
-  font-size: 1.2rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.app__title:hover {
+  color: #ffffff;
+  text-decoration: underline;
+}
+
+.app__subtitle {
+  font-size: 0.75rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+  font-weight: 600;
 }
 
 .app__nav {
   display: flex;
-  gap: 1rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
 }
 
-.app__nav a {
-  color: #eef6ff;
+.app__nav-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
   text-decoration: none;
-  font-weight: 500;
+  color: rgba(237, 242, 255, 0.8);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
 }
 
-.app__nav a:hover {
-  text-decoration: underline;
+.app__nav-link:hover {
+  background: rgba(255, 255, 255, 0.14);
+  color: #ffffff;
+}
+
+.app__nav-link--active {
+  background: linear-gradient(135deg, var(--color-accent-500) 0%, var(--color-accent-600) 100%);
+  color: #04170e;
+  box-shadow: 0 16px 28px rgba(52, 211, 153, 0.28);
 }
 
 .app__user {
@@ -64,37 +144,131 @@ textarea {
   gap: 0.75rem;
 }
 
-.app__user button {
-  background: rgba(255, 255, 255, 0.2);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  color: #fff;
-  padding: 0.3rem 0.75rem;
-  border-radius: 6px;
+.app__user-name {
+  color: #ffffff;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.app__user-action {
+  background: rgba(255, 255, 255, 0.14);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 999px;
+  padding: 0.5rem 1.15rem;
   cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app__user-action:hover {
+  background: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 10px 20px rgba(8, 26, 45, 0.25);
+}
+
+.app__user-login {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.25rem;
+  border-radius: 999px;
+  text-decoration: none;
+  background: linear-gradient(135deg, var(--color-accent-500) 0%, var(--color-accent-600) 100%);
+  color: #04170e;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  box-shadow: 0 16px 28px rgba(52, 211, 153, 0.28);
+}
+
+.app__user-login:hover {
+  filter: brightness(1.05);
 }
 
 .app__main {
   flex: 1;
-  padding: 1.5rem;
+  padding: 2.5rem 0 3.5rem;
+}
+
+.app__main-inner {
+  width: min(1120px, calc(100% - 3rem));
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 2rem;
 }
 
 .page {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 2rem;
 }
 
 .card {
-  background: #fff;
-  border-radius: 12px;
-  padding: 1.5rem;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  position: relative;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.98) 0%, rgba(237, 243, 255, 0.97) 100%);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 28px 80px rgba(6, 24, 51, 0.22);
+  border: 1px solid rgba(12, 44, 76, 0.1);
+  color: var(--color-text);
+  overflow: hidden;
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  pointer-events: none;
+  mix-blend-mode: soft-light;
+}
+
+.card h1,
+.card h2,
+.card h3 {
+  margin: 0;
+  font-family: 'Poppins', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  letter-spacing: 0.01em;
+  color: var(--color-text);
+}
+
+.card h1 {
+  font-size: 2rem;
+}
+
+.card h2 {
+  font-size: 1.35rem;
+}
+
+.card h3 {
+  font-size: 1.1rem;
+  margin-top: 1.5rem;
+}
+
+.card p {
+  margin: 0.6rem 0 0;
+  color: var(--color-text-muted);
+}
+
+.card--hero {
+  padding: 2.5rem;
+}
+
+.card--hero h1 {
+  font-size: 2.4rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.card--hero::after {
+  content: '';
+  position: absolute;
+  inset-inline-end: -140px;
+  inset-block-start: -160px;
+  width: 320px;
+  height: 320px;
+  background: radial-gradient(circle, rgba(148, 237, 200, 0.25) 0%, rgba(52, 211, 153, 0.12) 55%, transparent 80%);
+  pointer-events: none;
 }
 
 .card__header,
@@ -102,7 +276,7 @@ textarea {
 .form {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 1.25rem;
 }
 
 .card__header {
@@ -113,81 +287,177 @@ textarea {
 .form label {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  min-width: 200px;
+  gap: 0.45rem;
+  min-width: 220px;
+  color: var(--color-text);
 }
 
 .form input,
 .form select,
 .form textarea {
-  padding: 0.5rem 0.6rem;
-  border-radius: 6px;
-  border: 1px solid #cfd8e3;
-  background: #fdfdfd;
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(12, 44, 76, 0.18);
+  background: #ffffff;
+  color: var(--color-text);
+  box-shadow: inset 0 1px 2px rgba(12, 44, 76, 0.08);
 }
 
 button {
-  border-radius: 6px;
+  border-radius: 999px;
   border: none;
-  padding: 0.6rem 1.2rem;
-  background: #2458a6;
-  color: #fff;
+  padding: 0.65rem 1.4rem;
+  background: linear-gradient(135deg, var(--color-accent-500) 0%, var(--color-accent-600) 100%);
+  color: #04170e;
+  font-weight: 700;
+  letter-spacing: 0.02em;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+  box-shadow: 0 18px 36px rgba(52, 211, 153, 0.28);
 }
 
 button:hover {
-  background: #1d4888;
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+  box-shadow: 0 24px 42px rgba(34, 197, 94, 0.32);
+}
+
+button:active {
+  transform: translateY(0);
+  box-shadow: 0 12px 24px rgba(34, 197, 94, 0.28);
 }
 
 button.secondary {
-  background: #e0e7ff;
-  color: #1d2966;
+  background: rgba(16, 54, 89, 0.08);
+  color: var(--color-text);
+  border: 1px solid rgba(16, 54, 89, 0.18);
+  box-shadow: none;
+}
+
+button.secondary:hover {
+  background: rgba(16, 54, 89, 0.12);
 }
 
 .error {
-  color: #c62828;
-  font-weight: 500;
+  color: #b91c1c;
+  font-weight: 600;
 }
 
 .success {
-  color: #2e7d32;
-  font-weight: 500;
+  color: #15803d;
+  font-weight: 600;
 }
 
 .checkbox {
   flex-direction: row;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
 .table,
- table {
+table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: 16px;
+  overflow: hidden;
 }
 
 th,
- td {
-  padding: 0.5rem 0.75rem;
-  border-bottom: 1px solid #e5e9f2;
+td {
+  padding: 0.85rem 1rem;
   text-align: left;
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+thead tr {
+  background: linear-gradient(135deg, rgba(16, 54, 89, 0.95) 0%, rgba(26, 79, 125, 0.92) 100%);
+  color: #f8fafc;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+}
+
+thead th {
+  color: inherit;
+  font-weight: 700;
+}
+
+tbody tr {
+  transition: background 0.2s ease;
+}
+
+tbody tr:nth-child(odd) {
+  background: rgba(16, 54, 89, 0.04);
+}
+
+tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.92);
+}
+
+tbody tr:first-child td {
+  font-weight: 600;
+  color: #0b2440;
+}
+
+tbody tr:hover {
+  background: rgba(52, 211, 153, 0.16);
+}
+
+tbody td,
+tbody th {
+  border-bottom: 1px solid rgba(16, 54, 89, 0.12);
+}
+
+table tbody tr:last-child td {
+  border-bottom: none;
 }
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+@media (max-width: 960px) {
+  .app__header-inner,
+  .app__main-inner {
+    width: min(100%, calc(100% - 2rem));
+  }
 }
 
 @media (max-width: 720px) {
-  .app__header {
+  .app__header-inner {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: stretch;
+    text-align: center;
   }
+
+  .app__brand {
+    justify-content: center;
+  }
+
   .app__nav {
-    flex-wrap: wrap;
+    justify-content: center;
   }
+
+  .app__user {
+    justify-content: center;
+  }
+
+  .app__main {
+    padding: 2rem 0 3rem;
+  }
+
+  .card {
+    padding: 1.75rem;
+  }
+
+  .card--hero {
+    padding: 2rem;
+  }
+
   .form,
   .inline-form {
     flex-direction: column;

--- a/web/src/pages/LeaderboardPage.tsx
+++ b/web/src/pages/LeaderboardPage.tsx
@@ -63,7 +63,7 @@ export default function LeaderboardPage() {
 
   return (
     <div className="page">
-      <div className="card">
+      <div className="card card--hero">
         <h1>Výsledky</h1>
         <p>{data ? data.event.name : 'Načítám…'}</p>
         {loading ? <p>Načítám…</p> : null}


### PR DESCRIPTION
## Summary
- update the Seton-themed palette to use green accent variables instead of orange
- refresh active nav, login button, hero glow, and primary button shadows to match the green treatment
- adjust leaderboard row hover to use the new green highlight

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de8ecca344832683468b3e79b06a5f